### PR TITLE
Feat/pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "typescript-eslint-parser": "18.0.0"
   },
   "scripts": {
+    "preplop": "node scripts/check-node-version",
     "plop": "plop",
     "preclean": "node scripts/check-node-version",
     "clean": "node scripts/clean",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export { lastIndexOf } from "./lastIndexOf";
 export { map } from "./map";
 export { nth } from "./nth";
 export { of } from "./of";
+export { pipeline } from "./pipeline";
 export { reduce } from "./reduce";
 export { reject } from "./reject";
 export { scan } from "./scan";

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,142 @@
+import { isFunction } from "./__internal__/isFunction";
+
+export function pipeline<A extends any[], B>(
+  fn: (...args: A) => B
+): (...args: A) => B;
+
+export function pipeline<A extends any[], B, C>(
+  ...fns: [(...args: A) => B, (b: B) => C]
+): (...args: A) => C;
+
+export function pipeline<A extends any[], B, C, D>(
+  ...fns: [(...args: A) => B, (b: B) => C, (c: C) => D]
+): (...args: A) => D;
+
+export function pipeline<A extends any[], B, C, D, E>(
+  ...fns: [(...args: A) => B, (b: B) => C, (c: C) => D, (d: D) => E]
+): (...args: A) => E;
+
+export function pipeline<A extends any[], B, C, D, E, F>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F
+  ]
+): (...args: A) => F;
+
+export function pipeline<A extends any[], B, C, D, E, F, G>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G
+  ]
+): (...args: A) => G;
+
+export function pipeline<A extends any[], B, C, D, E, F, G, H>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G,
+    (g: G) => H
+  ]
+): (...args: A) => H;
+
+export function pipeline<A extends any[], B, C, D, E, F, G, H, I>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G,
+    (g: G) => H,
+    (h: H) => I
+  ]
+): (...args: A) => I;
+
+export function pipeline<A extends any[], B, C, D, E, F, G, H, I, J>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G,
+    (g: G) => H,
+    (h: H) => I,
+    (i: I) => J
+  ]
+): (...args: A) => J;
+
+export function pipeline<A extends any[], B, C, D, E, F, G, H, I, J, K>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G,
+    (g: G) => H,
+    (h: H) => I,
+    (i: I) => J,
+    (j: J) => K
+  ]
+): (...args: A) => K;
+
+export function pipeline<A extends any[], B, C, D, E, F, G, H, I, J, K, L>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G,
+    (g: G) => H,
+    (h: H) => I,
+    (i: I) => J,
+    (j: J) => K,
+    (k: K) => L
+  ]
+): (...args: A) => L;
+
+export function pipeline<A extends any[], B, C, D, E, F, G, H, I, J, K, L, M>(
+  ...fns: [
+    (...args: A) => B,
+    (b: B) => C,
+    (c: C) => D,
+    (d: D) => E,
+    (e: E) => F,
+    (f: F) => G,
+    (g: G) => H,
+    (h: H) => I,
+    (i: I) => J,
+    (j: J) => K,
+    (k: K) => L,
+    (l: L) => M
+  ]
+): (...args: A) => M;
+
+export function pipeline<A extends any[], R = any>(
+  ...fns: ((...args: any[]) => any)[]
+): (...args: A) => R;
+
+export function pipeline<A extends any[], R = any>(
+  fn1: (...args: A) => any,
+  ...fns: Function[]
+): (...args: A) => R {
+  if (!isFunction(fn1)) throw new Error("Must provide at least one function");
+
+  return function runPipeline(...args: A): R {
+    let result = fn1(...args);
+    for (let fn of fns) result = fn(result);
+    return result;
+  };
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -21,6 +21,7 @@ test.each([
   "map",
   "nth",
   "of",
+  "pipeline",
   "reduce",
   "reject",
   "scan",

--- a/test/pipeline.spec.js
+++ b/test/pipeline.spec.js
@@ -1,0 +1,4 @@
+import { pipeline } from "../src/pipeline";
+import { runPipelineSuite } from "./suites/runPipelineSuite";
+
+runPipelineSuite(pipeline);

--- a/test/suites/runPipelineSuite.js
+++ b/test/suites/runPipelineSuite.js
@@ -1,0 +1,54 @@
+import { filter } from "../../src/filter";
+import { of } from "../../src/of";
+import { map } from "../../src/map";
+import { toArray } from "../../src/toArray";
+
+export function runPipelineSuite(pipeline) {
+  test("throws an error when called with a non-function argument", () => {
+    expect.assertions(1);
+    expect(() => pipeline()).toThrowErrorMatchingInlineSnapshot(
+      `"Must provide at least one function"`
+    );
+  });
+
+  test("works with a single function", async () => {
+    expect.assertions(1);
+    let runPipeline = pipeline(n => n * 2);
+    expect(runPipeline(1)).toStrictEqual(2);
+  });
+
+  test("calls the first function with all of the arguments provided to the caller", async () => {
+    expect.assertions(1);
+    let mockFn = jest.fn();
+    pipeline(mockFn)("foo");
+    expect(mockFn).toHaveBeenCalledWith("foo");
+  });
+
+  test("calls the tail functions with the output of the previous step", async () => {
+    expect.assertions(3);
+
+    let mockFn1 = jest.fn().mockReturnValue("foo");
+    let mockFn2 = jest.fn().mockReturnValue("bar");
+    let mockFn3 = jest.fn().mockReturnValue("baz");
+    let mockFn4 = jest.fn();
+
+    pipeline(mockFn1, mockFn2, mockFn3, mockFn4)();
+
+    expect(mockFn2).toHaveBeenCalledWith("foo");
+    expect(mockFn3).toHaveBeenCalledWith("bar");
+    expect(mockFn4).toHaveBeenCalledWith("baz");
+  });
+
+  test("works with ICW methods", async () => {
+    expect.assertions(1);
+
+    let runPipeline = pipeline(
+      of,
+      _ => filter(_, n => n % 2 === 0),
+      _ => map(_, n => n ** 2),
+      toArray
+    );
+
+    await expect(runPipeline(1, 2, 3, 4, 5)).resolves.toStrictEqual([4, 16]);
+  });
+}


### PR DESCRIPTION
This adds a pipeline function that's useful for composing the standalone functions. It's analogous to `_.flow` or `R.pipe`.

The name is inspired by Node's `Stream.pipeline` and [the Pipeline Operator proposal](https://github.com/tc39/proposal-pipeline-operator).