### PR TITLE
Exclude strings from being flattened

### DIFF
--- a/src/flat.ts
+++ b/src/flat.ts
@@ -1,16 +1,24 @@
 import { from } from "./from";
 import { IterableLike } from "./IterableLike";
 import { isIterableLike } from "./__internal__/isIterableLike";
+import { isString } from "./__internal__/isString";
 
 export async function* flat<T>(
   iterableLike: IterableLike<T>,
   depth = 1
 ): AsyncIterableIterator<T> {
   for await (let value of from(iterableLike)) {
-    if (depth > 0 && isIterableLike<T>(value)) {
+    if (depth > 0 && isFlattenable(value)) {
       yield* flat(value, depth - 1);
     } else {
       yield value;
     }
   }
+}
+
+function isFlattenable<T>(
+  value: T | IterableLike<T>
+): value is IterableLike<T> {
+  if (isString(value)) return false;
+  return isIterableLike(value);
 }

--- a/test/suites/runConcatSuite.js
+++ b/test/suites/runConcatSuite.js
@@ -53,4 +53,24 @@ export function runConcatSuite(concat) {
       }
     }
   );
+
+  test.each`
+    inputType          | iterableLike
+    ${"AsyncIterable"} | ${of("foo")}
+    ${"Iterable"}      | ${["foo"]}
+    ${"ArrayLike"}     | ${new ArrayLike("foo")}
+    ${"Promise"}       | ${Promise.resolve("foo")}
+  `(
+    "treats strings as single values when concatenating to $inputType input",
+    async ({ iterableLike }) => {
+      expect.assertions(3);
+
+      let newValues = ["bar", "baz"];
+      let expectedValues = ["foo", "bar", "baz"];
+
+      for await (let value of concat(iterableLike, ...newValues)) {
+        expect(value).toStrictEqual(expectedValues.shift());
+      }
+    }
+  );
 }

--- a/test/suites/runFlatSuite.js
+++ b/test/suites/runFlatSuite.js
@@ -64,4 +64,20 @@ export function runFlatSuite(flat) {
       }
     }
   );
+
+  test.each`
+    inputType          | iterableLike              | expectedValues
+    ${"AsyncIterable"} | ${of("foo")}              | ${["foo"]}
+    ${"Iterable"}      | ${["foo"]}                | ${["foo"]}
+    ${"ArrayLike"}     | ${new ArrayLike("foo")}   | ${["foo"]}
+    ${"Promise"}       | ${Promise.resolve("foo")} | ${["foo"]}
+  `(
+    "does not flatten string values from $inputType input",
+    async ({ iterableLike, depth, expectedValues }) => {
+      expect.assertions(expectedValues.length);
+      for await (let value of flat(iterableLike, depth)) {
+        expect(value).toStrictEqual(expectedValues.shift());
+      }
+    }
+  );
 }


### PR DESCRIPTION
This seems like it would be unexpected behavior in most cases, especially when dealing with e.g. a file stream.