### PR TITLE
Add join and intersperse

### DIFF
--- a/src/ICW.ts
+++ b/src/ICW.ts
@@ -15,6 +15,7 @@ import { forEach } from "./forEach";
 import { from } from "./from";
 import { includes } from "./includes";
 import { indexOf } from "./indexOf";
+import { intersperse } from "./intersperse";
 import { last } from "./last";
 import { lastIndexOf } from "./lastIndexOf";
 import { map } from "./map";
@@ -72,6 +73,10 @@ export class ICW<T> implements AsyncIterableIterator<T> {
   }
 
   // plop: Prototype methods
+
+  intersperse<U>(separator: U): ICW<T | U> {
+    return new ICW(intersperse(this, separator));
+  }
 
   concat<U>(...values: U[]): ICW<T | U> {
     return new ICW(concat(this, ...values));

--- a/src/ICW.ts
+++ b/src/ICW.ts
@@ -16,6 +16,7 @@ import { from } from "./from";
 import { includes } from "./includes";
 import { indexOf } from "./indexOf";
 import { intersperse } from "./intersperse";
+import { join } from "./join";
 import { last } from "./last";
 import { lastIndexOf } from "./lastIndexOf";
 import { map } from "./map";
@@ -73,6 +74,10 @@ export class ICW<T> implements AsyncIterableIterator<T> {
   }
 
   // plop: Prototype methods
+
+  join(separator: string): Promise<string> {
+    return join(this, separator);
+  }
 
   intersperse<U>(separator: U): ICW<T | U> {
     return new ICW(intersperse(this, separator));

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export { head } from "./head";
 export { includes } from "./includes";
 export { indexOf } from "./indexOf";
 export { intersperse } from "./intersperse";
+export { join } from "./join";
 export { last } from "./last";
 export { lastIndexOf } from "./lastIndexOf";
 export { map } from "./map";

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export { from } from "./from";
 export { head } from "./head";
 export { includes } from "./includes";
 export { indexOf } from "./indexOf";
+export { intersperse } from "./intersperse";
 export { last } from "./last";
 export { lastIndexOf } from "./lastIndexOf";
 export { map } from "./map";

--- a/src/intersperse.ts
+++ b/src/intersperse.ts
@@ -1,0 +1,15 @@
+import { from } from "./from";
+import { IterableLike } from "./IterableLike";
+
+export async function* intersperse<T, S>(
+  iterableLike: IterableLike<T>,
+  separator: S
+): AsyncIterableIterator<T | S> {
+  let shouldYieldSeparator = false;
+
+  for await (let value of from(iterableLike)) {
+    if (shouldYieldSeparator) yield separator;
+    yield value;
+    shouldYieldSeparator = true;
+  }
+}

--- a/src/join.ts
+++ b/src/join.ts
@@ -1,0 +1,15 @@
+import { IterableLike } from "./IterableLike";
+import { intersperse } from "./intersperse";
+
+export async function join<T>(
+  iterableLike: IterableLike<T>,
+  separator = ","
+): Promise<string> {
+  let joinedValues = "";
+
+  for await (let value of intersperse(iterableLike, separator)) {
+    joinedValues += String(value);
+  }
+
+  return joinedValues;
+}

--- a/test/ICW.spec.js
+++ b/test/ICW.spec.js
@@ -19,6 +19,7 @@ import { runHeadSuite } from "./suites/runHeadSuite";
 import { runIncludesSuite } from "./suites/runIncludesSuite";
 import { runIndexOfSuite } from "./suites/runIndexOfSuite";
 import { runIntersperseSuite } from "./suites/runIntersperseSuite";
+import { runJoinSuite } from "./suites/runJoinSuite";
 import { runLastIndexOfSuite } from "./suites/runLastIndexOfSuite";
 import { runLastSuite } from "./suites/runLastSuite";
 import { runMapSuite } from "./suites/runMapSuite";
@@ -144,6 +145,7 @@ describe.each`
   ${"includes"}      | ${runIncludesSuite}
   ${"indexOf"}       | ${runIndexOfSuite}
   ${"intersperse"}   | ${runIntersperseSuite}
+  ${"join"}          | ${runJoinSuite}
   ${"last"}          | ${runLastSuite}
   ${"lastIndexOf"}   | ${runLastIndexOfSuite}
   ${"map"}           | ${runMapSuite}

--- a/test/ICW.spec.js
+++ b/test/ICW.spec.js
@@ -18,6 +18,7 @@ import { runFromSuite } from "./suites/runFromSuite";
 import { runHeadSuite } from "./suites/runHeadSuite";
 import { runIncludesSuite } from "./suites/runIncludesSuite";
 import { runIndexOfSuite } from "./suites/runIndexOfSuite";
+import { runIntersperseSuite } from "./suites/runIntersperseSuite";
 import { runLastIndexOfSuite } from "./suites/runLastIndexOfSuite";
 import { runLastSuite } from "./suites/runLastSuite";
 import { runMapSuite } from "./suites/runMapSuite";
@@ -142,6 +143,7 @@ describe.each`
   ${"head"}          | ${runHeadSuite}
   ${"includes"}      | ${runIncludesSuite}
   ${"indexOf"}       | ${runIndexOfSuite}
+  ${"intersperse"}   | ${runIntersperseSuite}
   ${"last"}          | ${runLastSuite}
   ${"lastIndexOf"}   | ${runLastIndexOfSuite}
   ${"map"}           | ${runMapSuite}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -20,6 +20,7 @@ test.each([
   "includes",
   "indexOf",
   "intersperse",
+  "join",
   "last",
   "lastIndexOf",
   "map",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -19,6 +19,7 @@ test.each([
   "head",
   "includes",
   "indexOf",
+  "intersperse",
   "last",
   "lastIndexOf",
   "map",

--- a/test/intersperse.spec.js
+++ b/test/intersperse.spec.js
@@ -1,0 +1,4 @@
+import { intersperse } from "../src/intersperse";
+import { runIntersperseSuite } from "./suites/runIntersperseSuite";
+
+runIntersperseSuite(intersperse);

--- a/test/join.spec.js
+++ b/test/join.spec.js
@@ -1,0 +1,4 @@
+import { join } from "../src/join";
+import { runJoinSuite } from "./suites/runJoinSuite";
+
+runJoinSuite(join);

--- a/test/suites/runIntersperseSuite.js
+++ b/test/suites/runIntersperseSuite.js
@@ -1,0 +1,65 @@
+import { of } from "../../src/of";
+import { ArrayLike } from "../helpers/ArrayLike";
+
+export function runIntersperseSuite(intersperse) {
+  test("returns same async iterator", () => {
+    expect.assertions(1);
+    expect(intersperse(of())).toReturnSameAsyncIterator();
+  });
+
+  test("returns a closeable iterator", async () => {
+    expect.assertions(1);
+    await expect(intersperse(of())).toBeCloseableAsyncIterator();
+  });
+
+  test("lazily consumes provided IterableLike input", async () => {
+    expect.assertions(1);
+    await expect(_ => intersperse(_)).toLazilyConsumeWrappedAsyncIterable();
+  });
+
+  test.each`
+    inputType          | iterableLike                          | separator | expectedValues
+    ${"AsyncIterable"} | ${of("foo", "bar", "baz")}            | ${"|"}    | ${["foo", "|", "bar", "|", "baz"]}
+    ${"Iterable"}      | ${["foo", "bar", "baz"]}              | ${"|"}    | ${["foo", "|", "bar", "|", "baz"]}
+    ${"ArrayLike"}     | ${new ArrayLike("foo", "bar", "baz")} | ${"|"}    | ${["foo", "|", "bar", "|", "baz"]}
+  `(
+    "adds separator between each yielded value from $inputType input",
+    async ({ iterableLike, separator, expectedValues }) => {
+      expect.assertions(expectedValues.length);
+      for await (let value of intersperse(iterableLike, separator)) {
+        expect(value).toStrictEqual(expectedValues.shift());
+      }
+    }
+  );
+
+  test.each`
+    inputType          | iterableLike                          | expectedValues
+    ${"AsyncIterable"} | ${of("foo", "bar", "baz")}            | ${["foo", undefined, "bar", undefined, "baz"]}
+    ${"Iterable"}      | ${["foo", "bar", "baz"]}              | ${["foo", undefined, "bar", undefined, "baz"]}
+    ${"ArrayLike"}     | ${new ArrayLike("foo", "bar", "baz")} | ${["foo", undefined, "bar", undefined, "baz"]}
+  `(
+    "uses `undefined` as default separator between each yielded value from $inputType input",
+    async ({ iterableLike, separator, expectedValues }) => {
+      expect.assertions(expectedValues.length);
+      for await (let value of intersperse(iterableLike, separator)) {
+        expect(value).toStrictEqual(expectedValues.shift());
+      }
+    }
+  );
+
+  test.each`
+    inputType          | iterableLike              | expectedValues
+    ${"AsyncIterable"} | ${of("foo")}              | ${["foo"]}
+    ${"Iterable"}      | ${["foo"]}                | ${["foo"]}
+    ${"ArrayLike"}     | ${new ArrayLike("foo")}   | ${["foo"]}
+    ${"Promise"}       | ${Promise.resolve("foo")} | ${["foo"]}
+  `(
+    "does not add a separator if only one value is yielded from $inputType input",
+    async ({ iterableLike, expectedValues }) => {
+      expect.assertions(expectedValues.length);
+      for await (let value of intersperse(iterableLike)) {
+        expect(value).toStrictEqual(expectedValues.shift());
+      }
+    }
+  );
+}

--- a/test/suites/runJoinSuite.js
+++ b/test/suites/runJoinSuite.js
@@ -1,0 +1,51 @@
+import { of } from "../../src/of";
+import { ArrayLike } from "../helpers/ArrayLike";
+
+export function runJoinSuite(join) {
+  test("eagerly consumes wrapped IterableLike input", async () => {
+    expect.assertions(1);
+    await expect(_ => join(_)).toEagerlyConsumeWrappedAsyncIterable();
+  });
+
+  test.each`
+    inputType          | iterableLike                          | separator | expectedValue
+    ${"AsyncIterable"} | ${of("foo", "bar", "baz")}            | ${"|"}    | ${"foo|bar|baz"}
+    ${"Iterable"}      | ${["foo", "bar", "baz"]}              | ${"|"}    | ${"foo|bar|baz"}
+    ${"ArrayLike"}     | ${new ArrayLike("foo", "bar", "baz")} | ${"|"}    | ${"foo|bar|baz"}
+  `(
+    "adds separator between each yielded value from $inputType input",
+    async ({ iterableLike, separator, expectedValue }) => {
+      expect.assertions(1);
+      await expect(join(iterableLike, separator)).resolves.toStrictEqual(
+        expectedValue
+      );
+    }
+  );
+
+  test.each`
+    inputType          | iterableLike                          | expectedValue
+    ${"AsyncIterable"} | ${of("foo", "bar", "baz")}            | ${"foo,bar,baz"}
+    ${"Iterable"}      | ${["foo", "bar", "baz"]}              | ${"foo,bar,baz"}
+    ${"ArrayLike"}     | ${new ArrayLike("foo", "bar", "baz")} | ${"foo,bar,baz"}
+  `(
+    " uses `,` as default separator between each yielded value from $inputType input",
+    async ({ iterableLike, expectedValue }) => {
+      expect.assertions(1);
+      await expect(join(iterableLike)).resolves.toStrictEqual(expectedValue);
+    }
+  );
+
+  test.each`
+    inputType          | iterableLike              | expectedValue
+    ${"AsyncIterable"} | ${of("foo")}              | ${"foo"}
+    ${"Iterable"}      | ${["foo"]}                | ${"foo"}
+    ${"ArrayLike"}     | ${new ArrayLike("foo")}   | ${"foo"}
+    ${"Promise"}       | ${Promise.resolve("foo")} | ${"foo"}
+  `(
+    "does not add a separator if only one value is yielded from $inputType input",
+    async ({ iterableLike, expectedValue }) => {
+      expect.assertions(1);
+      await expect(join(iterableLike)).resolves.toStrictEqual(expectedValue);
+    }
+  );
+}


### PR DESCRIPTION
Adding them both in one PR because `join` uses `intersperse` under the hood.

Closes #9 